### PR TITLE
Dev

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,13 +15,13 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "publisher": "Microsoft",
       "name": "System Application",
-      "version": "16.0.0.0"
+      "version": "16.1.12629.13468"
     },
     {
       "id": "437dbf0e-84ff-417a-965d-ed2bb9650972",
       "publisher": "Microsoft",
       "name": "Base Application",
-      "version": "16.0.0.0"
+      "version": "16.1.12629.13468"
     }
   ],
   "screenshots": [],

--- a/app.json
+++ b/app.json
@@ -15,13 +15,19 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "publisher": "Microsoft",
       "name": "System Application",
-      "version": "16.1.12629.13468"
+      "version": "16.0.0.0"
     },
     {
       "id": "437dbf0e-84ff-417a-965d-ed2bb9650972",
       "publisher": "Microsoft",
       "name": "Base Application",
-      "version": "16.1.12629.13468"
+      "version": "16.0.0.0"
+    },
+    {
+      "id": "c1335042-3002-4257-bf8a-75c898ccb1b8",
+      "publisher": "Microsoft",
+      "name": "Application",
+      "version": "16.0.0.0"
     }
   ],
   "screenshots": [],

--- a/setup.json
+++ b/setup.json
@@ -1,0 +1,8 @@
+﻿{
+    "branchId":  "436bab17-2b24-472e-b250-7477c17a45b0",
+    "navSolution":  "W1",
+    "projectName":  "Inv-Exch",
+    "navVersion":  "16.0.0.0",
+    "dockerImage":  "mcr.microsoft.com/businesscentral/sandbox:16.1.12629.13468-w1",
+    "dockerShared":  ""
+}


### PR DESCRIPTION
App json dependecies proširen za još jedan app pod nazivom Application. Razvoj je moguće raditi samo sa ovim app-om u app json fajlu, bez potrebe da se eksplicitno definiše zavisnost od Base Application i System Application. Zašto je tako? Pogledati link za business central app i launch json, sa posebnim akcentom na property (u app json fajlu) propagateDependecies

U setup json fajlu je definisan dockerImage koji ću ja koristiti. Setup json ti nije potreban za podizanje okruženja, izuzev da vidiš koji image koristim. Zašto je ovako Setup json struktuiran ako ti ne treba ništa drugo sem informacije koji image koristim? Koristi se u VS Code ekstenziji AdvaniaGit. VS Code ekstenzija AdvaniaGit se može besplatno skinuti i predstavlja Source Control Management. Njome se, preko PowerShell skripti, kreiraju veze između lokalnog i remote repozitorijuma kao i veza sa NavContainerHelper skriptom. Recimo da bi se podiglo novo okruženje, dovoljno je izvršiti VS Code naredbu (CTRL + Shift + P) Advania: Build new NAV Environment. Ova naredba pokreće PowerShell skiput koja će proveriti da li u lokalnom repozitorijumu imaš definisan Setup json fajl, pa će uzeti podatak iz polja DockerImage i pozvati Fredijevu  skriptu i kreirati kontejner, kontejneru će dati ono ime koje je definisano u setup json fajlu (npr Inv-Exch) itd. Suština ove ekstenzije je da ne moraš raditi ništa u terminalu, powershell... već sve kroz VS Code preko VS Code naredbi. Ne moraš je instalirati, to je opciono. Meni svakako dosta pomaže 